### PR TITLE
Support actions on FOREIGN_KEY constraints

### DIFF
--- a/src/Sqlite3/Cmd.idr
+++ b/src/Sqlite3/Cmd.idr
@@ -39,6 +39,38 @@ public export %inline
   -> Val t
 (.=) name v = V name (rewrite eq in val v)
 
+
+namespace ForeignKey
+  ||| Foreign Key Actions
+  public export
+  data Action
+    = SET_NULL
+    | SET_DEFAULT
+    | CASCADE
+    | RESTRICT
+    | NO_ACTION
+
+  ||| Foreign key constraint which supports actions.
+  public export
+  record Details (xs : List SqliteType ) (t : SQLTable) where
+    constructor MkDetails
+    target      : SQLTable
+    my_cols     : LAll (TColumn t) xs
+    target_cols : LAll (TColumn target) xs
+    on_update   : Action
+    on_delete   : Action
+
+  ||| Add ON_UPDATE action to the given foreign key constraint.
+  public export
+  ON_UDPATE : Details xs t -> Action -> Details xs t
+  ON_UDPATE details action = { on_update := action } details
+
+  ||| Add ON_DELETE action to this foreign key constraint
+  public export
+  ON_DELETE : Details xs t -> Action -> Details xs t
+  ON_DELETE details action = { on_delete := action } details
+
+
 ||| Column and table constraints to be used when creating a new table.
 public export
 data Constraint : SQLTable -> Type where
@@ -46,13 +78,7 @@ data Constraint : SQLTable -> Type where
   AUTOINCREMENT : {0 x : _} -> TColumn t x -> Constraint t
   UNIQUE        : {0 xs : _} -> LAll (TColumn t) xs -> Constraint t
   PRIMARY_KEY   : {0 xs : _} -> LAll (TColumn t) xs -> Constraint t
-  FOREIGN_KEY   :
-       {0 xs : _}
-    -> (s       : SQLTable)
-    -> LAll (TColumn t) xs
-    -> LAll (TColumn s) xs
-    -> Constraint t
-
+  ForeignKey    : {0 xs : _} -> ForeignKey.Details xs t -> Constraint t
   CHECK         : Expr [<t] BOOL -> Constraint t
   DEFAULT       :
        {0 t        : SQLTable}
@@ -60,6 +86,20 @@ data Constraint : SQLTable -> Type where
     -> {auto 0 prf : IsJust (FindCol s t.cols)}
     -> (expr       : Expr [<t] (TableColType s t))
     -> Constraint t
+
+
+||| Convenience eAPI to Construct a foreign key constraint.
+public export
+FOREIGN_KEY   :
+     {0 xs : _}
+  -> {0 t : SQLTable}
+  -> (s   : SQLTable)
+  -> LAll (TColumn t) xs
+  -> LAll (TColumn s) xs
+  -> Constraint t
+FOREIGN_KEY s a b = ForeignKey $ MkDetails s a b NO_ACTION NO_ACTION
+
+
 
 ||| Index used to distinguish different types of commands.
 |||

--- a/src/Sqlite3/Parameter.idr
+++ b/src/Sqlite3/Parameter.idr
@@ -165,23 +165,20 @@ encodeDflt x         = "DEFAULT (\{encodeExpr x})"
 references : (t : SQLTable) -> LAll (TColumn t) xs -> String
 references t cs = "REFERENCES \{t.name} (\{names [<] cs})"
 
-action : ForeignKey.Action -> String
-action SET_NULL    = "SET NULL"
-action SET_DEFAULT = "SET DEFAULT"
-action CASCADE     = "CASCADE"
-action RESTRICT    = "RESTRICT"
-action NO_ACTION   = "NO ACTION"
+encAction : Action -> String
+encAction SET_NULL    = "SET NULL"
+encAction SET_DEFAULT = "SET DEFAULT"
+encAction CASCADE     = "CASCADE"
+encAction RESTRICT    = "RESTRICT"
+encAction NO_ACTION   = "NO ACTION"
 
-actions : ForeignKey.Action -> ForeignKey.Action -> String
-actions NO_ACTION NO_ACTION = ""
-actions update    NO_ACTION = " ON UPDATE \{action update}"
-actions NO_ACTION delete    = " ON DELETE \{action delete}"
-actions update    delete    = " ON UPDATE \{action update} ON DELETE \{action update}"
+encEvent : Event -> String
+encEvent (ON_UPDATE a) = "ON UPDATE \{encAction a}"
+encEvent (ON_DELETE a) = "ON DELETE \{encAction a}"
 
-encDetails : Constraints -> ForeignKey.Details xs t -> Constraints
-encDetails y (MkDetails s [p] ys u d) = addCol y p.name "\{references s ys}\{actions u d}" 
-encDetails y (MkDetails s xs  ys u d) = addTbl y
-  "FOREIGN KEY (\{names [<] xs}) \{references s ys} \{actions u d}"
+encEvents : List Event -> String
+encEvents [] = ""
+encEvents xs = " \{unwords $ map encEvent xs}"
 
 encConstraint : Constraints -> Constraint t -> Constraints
 encConstraint y (NOT_NULL $ TC n)      = addCol y n"NOT NULL"
@@ -192,7 +189,9 @@ encConstraint y (DEFAULT s expr)       = addCol y s (encodeDflt expr)
 encConstraint y (UNIQUE xs)            = addTbl y "UNIQUE (\{names [<] xs})"
 encConstraint y (PRIMARY_KEY xs)       = addTbl y "PRIMARY KEY (\{names [<] xs})"
 encConstraint y (CHECK x)              = addTbl y "CHECK (\{encodeExpr x})"
-encConstraint y (ForeignKey details)   = encDetails y details
+encConstraint y (ForeignKey s [p] ys as) = addCol y p.name "\{references s ys}\{encEvents as}"
+encConstraint y (ForeignKey s xs  ys as) = addTbl y
+  "FOREIGN KEY (\{names [<] xs}) \{references s ys} \{encEvents as}"
 
 ine : Bool -> String
 ine True  = "IF NOT EXISTS"

--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -89,5 +89,10 @@ app = withDB ":memory:" $ do
 
   queryTable parents 1000 >>= printTable
 
+  cmds $ [ deleteEmployee "Ben" ]
+
+  queryTable heads 1000 >>= printTable
+
+
 main : IO ()
 main = runApp handlers app

--- a/test/src/Schema.idr
+++ b/test/src/Schema.idr
@@ -82,7 +82,7 @@ createUnits =
   CREATE_TABLE Units
     [ PRIMARY_KEY ["unit_id"]
     , AUTOINCREMENT "unit_id"
-    , FOREIGN_KEY Employees ["head"] ["employee_id"]
+    , FOREIGN_KEY' Employees ["head"] ["employee_id"] $ [ON_UPDATE CASCADE]
     , NOT_NULL "name"
     , UNIQUE ["name"]
     ]
@@ -177,6 +177,10 @@ insertFile = insert Files ["content"]
 export
 insertEdge : String -> String -> Cmd TInsert
 insertEdge u v = INSERT Edges ["u", "v"] [val u, val v]
+
+export
+deleteEmployee : String -> Cmd TDelete
+deleteEmployee name = DELETE Employees ("name" == val name)
 
 --------------------------------------------------------------------------------
 -- Query

--- a/test/src/Schema.idr
+++ b/test/src/Schema.idr
@@ -82,7 +82,7 @@ createUnits =
   CREATE_TABLE Units
     [ PRIMARY_KEY ["unit_id"]
     , AUTOINCREMENT "unit_id"
-    , FOREIGN_KEY' Employees ["head"] ["employee_id"] $ [ON_UPDATE CASCADE]
+    , FOREIGN_KEY' Employees ["head"] ["employee_id"] $ [ON_DELETE CASCADE]
     , NOT_NULL "name"
     , UNIQUE ["name"]
     ]


### PR DESCRIPTION
I tried to do this in the simplest way possible, though there are things I don't like about it.

- renamed `FOREIGN_KEY` variant to `ForeignKey`
- helper function `FOREIGN_KEY` retains previous behavior
- new helper function `FOREIGN_KEY'` allows passing `ON_UPDATE` and `ON_DELETE`

All actions are supported
- NO_ACTION
- SET_NULL
- SET_DEFAULT
- RESTRICT
- CASCADE

Added a test using `CASCADE` to verify that the action was added to the foreign key constraint.